### PR TITLE
Allow specifying TemplateID in ReinstallMetalRequest

### DIFF
--- a/metal.go
+++ b/metal.go
@@ -393,6 +393,7 @@ type ReinstallMetalRequest struct {
 	RaidArrays  []RaidArray `json:"raidArrays,omitempty"`
 	SSHKeyIDs   []int       `json:"sshKeyIds,omitempty"`
 	UserData    string      `json:"userData,omitempty"`
+	TemplateID  int64       `json:"templateId,omitempty"`
 }
 
 // ReinstallMetalService reinstalls a metal service by ID


### PR DESCRIPTION
This MR updates ReinstallMetalRequest to allow directly specifying the TemplateID as per the TeraSwitch API.