### PR TITLE
feat: add tier into Metal struct

### DIFF
--- a/metal.go
+++ b/metal.go
@@ -26,9 +26,10 @@ type Metal struct {
 	PowerState PowerState `json:"powerState"`
 
 	// Hardware configuration
-	TierID   string `json:"tierId"`
-	MemoryGB int32  `json:"memoryGb"`
-	ImageID  string `json:"imageId"`
+	TierID         string                        `json:"tierId"`
+	Tier           MetalTier                     `json:"tier"`
+	MemoryGB       int32                         `json:"memoryGb"`
+	ImageID        string                        `json:"imageId"`
 	StorageDevices map[string]MetalStorageDevice `json:"storageDevices"`
 
 	// Network configuration


### PR DESCRIPTION
#### Problem

it looks like the cpu info is only available in the tier field. we can definitely use the tier id to map it. however, I noticed that the API already returns the full information, so we can just use that

#### Summary of Changes

add Tier into the Metal struct