### PR TITLE
Add tier struct for cpu details

### DIFF
--- a/metal.go
+++ b/metal.go
@@ -26,9 +26,14 @@ type Metal struct {
 	PowerState PowerState `json:"powerState"`
 
 	// Hardware configuration
-	TierID   string `json:"tierId"`
-	MemoryGB int32  `json:"memoryGb"`
-	ImageID  string `json:"imageId"`
+	TierID string `json:"tierId"`
+	Tier   struct {
+		ID             string `json:"id"`
+		CPU            string `json:"cpu"`
+		CPUDescription string `json:"cpuDescription"`
+	} `json:"tier"`
+	MemoryGB       int32                         `json:"memoryGb"`
+	ImageID        string                        `json:"imageId"`
 	StorageDevices map[string]MetalStorageDevice `json:"storageDevices"`
 
 	// Network configuration
@@ -397,14 +402,14 @@ func (c *Client) GetMetalService(ctx context.Context, id int64) (*MetalResponse,
 }
 
 type ReinstallMetalRequest struct {
-	DisplayName     string           `json:"displayName,omitempty"`
-	ImageID         string           `json:"imageId,omitempty"`
-	SSHKeyIDs       []int64           `json:"sshKeyIds,omitempty"`
-	Password        string           `json:"password,omitempty"`
-	UserData        string           `json:"userData,omitempty"`
-	IPXEUrl         string           `json:"ipxeUrl,omitempty"`
-	Partitions      []Partition       `json:"partitions,omitempty"`
-	RaidArrays      []RaidArray       `json:"raidArrays,omitempty"`
+	DisplayName string      `json:"displayName,omitempty"`
+	ImageID     string      `json:"imageId,omitempty"`
+	SSHKeyIDs   []int64     `json:"sshKeyIds,omitempty"`
+	Password    string      `json:"password,omitempty"`
+	UserData    string      `json:"userData,omitempty"`
+	IPXEUrl     string      `json:"ipxeUrl,omitempty"`
+	Partitions  []Partition `json:"partitions,omitempty"`
+	RaidArrays  []RaidArray `json:"raidArrays,omitempty"`
 }
 
 // ReinstallMetalService reinstalls a metal service by ID

--- a/metal.go
+++ b/metal.go
@@ -26,12 +26,8 @@ type Metal struct {
 	PowerState PowerState `json:"powerState"`
 
 	// Hardware configuration
-	TierID string `json:"tierId"`
-	Tier   struct {
-		ID             string `json:"id"`
-		CPU            string `json:"cpu"`
-		CPUDescription string `json:"cpuDescription"`
-	} `json:"tier"`
+	TierID         string                        `json:"tierId"`
+	Tier           CpuDetails                    `json:"tier"`
 	MemoryGB       int32                         `json:"memoryGb"`
 	ImageID        string                        `json:"imageId"`
 	StorageDevices map[string]MetalStorageDevice `json:"storageDevices"`
@@ -284,6 +280,13 @@ type MetalTier struct {
 	DriveSlotSetID     int                             `json:"driveSlotSetId"`
 	NetworkOptionSetID int                             `json:"networkOptionSetId"`
 	TierType           MetalTierType                   `json:"tierType"`
+}
+
+// CpuDetails represents the CPU details for a metal tier
+type CpuDetails struct {
+	ID             string `json:"id"`             // ID of the CPU
+	CPU            string `json:"cpu"`            // The CPU model for the tier
+	CPUDescription string `json:"cpuDescription"` // Description of CPU (cores/threads)
 }
 
 // ServiceAvailability represents the availability of a service in a region


### PR DESCRIPTION
Only exposing cpu details in the metal tier when listing or getting a metal service